### PR TITLE
Typo in README: `markdown-it` to `markdownit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ for an example of usage in NodeJS.
     ```
     <script src="[cdnjs.com link for markdown-it]"></script>
     <script src="[cdnjs.com link for markdown-it-chords]"></script>
-    <script>const md = window.markdown-it('commonmark').use(window.markdownItChords)</script>
+    <script>const md = window.markdownit('commonmark').use(window.markdownItChords)</script>
     ```
 
 2. Do what you want in the body of the document:


### PR DESCRIPTION
In the browser-code block, there is not dash in `markdown-it` as documented in https://cdnjs.cloudflare.com/ajax/libs/markdown-it/12.2.0/markdown-it.min.js. 

In the example `readme.js` it is correct https://github.com/dnotes/markdown-it-chords/blob/master/readme.js#L24